### PR TITLE
Fix Polaris PrComment Issue with Extra Spaces in polaris_prComment_severities Input

### DIFF
--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -269,8 +269,11 @@ public class PolarisParametersService {
                                 .toString()
                                 .trim();
                         if (!prCommentSeveritiesValue.isEmpty()) {
-                            List<String> prCommentSeverities = Arrays.asList(
-                                    prCommentSeveritiesValue.toUpperCase().split(","));
+                            List<String> prCommentSeverities = Arrays.stream(prCommentSeveritiesValue
+                                            .toUpperCase()
+                                            .split(","))
+                                    .map(String::trim)
+                                    .collect(Collectors.toList());
                             prcomment.setSeverities(prCommentSeverities);
                         }
                     }

--- a/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
@@ -158,7 +158,7 @@ public class PolarisParametersServiceTest {
         polarisParameters.put(ApplicationConstants.POLARIS_BRANCH_NAME_KEY, "test-branch");
         polarisParameters.put(ApplicationConstants.POLARIS_BRANCH_PARENT_NAME_KEY, "test-parent-branch");
         polarisParameters.put(ApplicationConstants.POLARIS_PRCOMMENT_ENABLED_KEY, true);
-        polarisParameters.put(ApplicationConstants.POLARIS_PRCOMMENT_SEVERITIES_KEY, "HIGH");
+        polarisParameters.put(ApplicationConstants.POLARIS_PRCOMMENT_SEVERITIES_KEY, "CRITICAL, HIGH, MEDIUM");
         polarisParameters.put(ApplicationConstants.POLARIS_TEST_SCA_TYPE_KEY, "SCA-SIGNATURE");
         polarisParameters.put(ApplicationConstants.POLARIS_WAITFORSCAN_KEY, true);
 
@@ -174,7 +174,7 @@ public class PolarisParametersServiceTest {
         assertEquals(polaris.getBranch().getName(), "test-branch");
         assertEquals(polaris.getBranch().getParent().getName(), "test-parent-branch");
         assertEquals(polaris.getPrcomment().getEnabled(), true);
-        assertEquals(polaris.getPrcomment().getSeverities(), List.of("HIGH"));
+        assertEquals(polaris.getPrcomment().getSeverities(), List.of("CRITICAL", "HIGH", "MEDIUM"));
         assertEquals(polaris.getTest().getSca().getType(), "SCA-SIGNATURE");
         assertEquals(polaris.isWaitForScan(), true);
     }


### PR DESCRIPTION
PR Comments for Polaris are not getting identified due to extra spaces in `polaris_prComment_severities` values. As part of the fix, the spaces are trimmed off for the  `polaris_prComment_severities` values before sending those to bridge-cli.