### PR TITLE
Fix for INTEGRATE-204: Jenkins Security Scan plugin freestyle job does not add link to Coverity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <revision>2.2.0</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <changelist>SNAPSHOT</changelist>
     <jenkins.version>2.440.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
@@ -133,7 +133,9 @@ public class IssueCalculator {
     // Helper method for case-insensitive key lookup
     private JsonNode getCaseInsensitiveNode(JsonNode node, String key) {
         if (node == null || node.isMissingNode()) return node;
-        for (String fieldName : (Iterable<String>) node::fieldNames) {
+        Iterator<String> fieldNamesIterator = node.fieldNames();
+        while (fieldNamesIterator.hasNext()) {
+            String fieldName = fieldNamesIterator.next();
             if (fieldName.equalsIgnoreCase(key)) {
                 return node.get(fieldName);
             }

--- a/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
@@ -139,7 +139,7 @@ public class IssueCalculator {
         while (fieldNamesIterator.hasNext()) {
             String fieldName = fieldNamesIterator.next();
             if (fieldName.equalsIgnoreCase(key)) {
-                return node.get(fieldName);
+                return node.path(fieldName);
             }
         }
         return node.path(key); // fallback to default

--- a/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.jenkins.plugins.security.scan.global.enums.AssessmentType;
 import io.jenkins.plugins.security.scan.global.enums.IssueSeverities;
 import io.jenkins.plugins.security.scan.global.enums.SecurityProduct;
+import java.util.Iterator;
 
 public class IssueCalculator {
 

--- a/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
@@ -139,7 +139,8 @@ public class IssueCalculator {
                 }
             }
             if (!found) {
-                current = current.path(key); // fallback
+                // Fallback to a case-sensitive lookup if no case-insensitive match is found.
+                current = current.path(key);
             }
         }
         return current;

--- a/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/IssueCalculator.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.security.scan.global;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.jenkins.plugins.security.scan.global.enums.AssessmentType;
-import io.jenkins.plugins.security.scan.global.enums.IssueSeverities;
 import io.jenkins.plugins.security.scan.global.enums.SecurityProduct;
 import java.util.Iterator;
 
@@ -122,8 +121,10 @@ public class IssueCalculator {
             JsonNode issuesNode = getCaseInsensitiveNode(testNode, ISSUES_PROPERTY);
             if (!issuesNode.isMissingNode()) {
                 int total = 0;
-                for (IssueSeverities severity : IssueSeverities.values()) {
-                    total += getCaseInsensitiveNode(issuesNode, severity.name()).asInt(0);
+                Iterator<String> fieldNames = issuesNode.fieldNames();
+                while (fieldNames.hasNext()) {
+                    String field = fieldNames.next();
+                    total += issuesNode.path(field).asInt(0);
                 }
                 return total;
             }

--- a/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
@@ -99,4 +99,47 @@ public class IssueCalculatorTest {
 
         assertEquals(14, totalIssues);
     }
+
+    @Test
+    public void testCalculateBlackDuckScaIssues_CaseInsensitive() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"BLACKDUCKSCA\": {\"policy\": {\"status\": {\"issues\": {\"CRITICAL\": 1, \"high\": 2}}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "blackducksca";
+        int totalIssues = issueCalculator.calculateTotalIssues(rootNode, product);
+        assertEquals(3, totalIssues);
+    }
+
+    @Test
+    public void testCalculateCoverityIssues_CaseInsensitive() throws IOException {
+        String jsonContent = "{" + "\"data\": {\"COVERITY\": {\"CONNECT\": {\"policy\": {\"issueCount\": 7}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "coverity";
+        int totalIssues = issueCalculator.calculateTotalIssues(rootNode, product);
+        assertEquals(7, totalIssues);
+    }
+
+    @Test
+    public void testCalculatePolarisIssues_CaseInsensitive() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"POLARIS\": {\"test\": {\"SAST\": {\"TESTS\": {\"FULL\": {\"issues\": {\"CRITICAL\": 2, \"high\": 3}}}}, \"SCA\": {\"tests\": {\"SCAPACKAGE\": {\"IsSuEs\": {\"medium\": 4, \"LOW\": 5}}}}}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "polaris";
+        int totalIssues = issueCalculator.calculateTotalIssues(rootNode, product);
+        assertEquals(14, totalIssues);
+    }
+
+    @Test
+    public void testCalculateSrmIssues_CaseInsensitive() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"SRM\": {\"analysis\": {\"issues\": {\"CRITICAL\": 1, \"HIGH\": 2, \"medium\": 3, \"LOW\": 4}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "srm";
+        int totalIssues = issueCalculator.calculateTotalIssues(rootNode, product);
+        assertEquals(10, totalIssues);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
@@ -1,18 +1,19 @@
 package io.jenkins.plugins.security.scan.global;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class IssueCalculatorTest {
     IssueCalculator issueCalculator = new IssueCalculator();
 
     @Test
-    public void testGetIssuesUrl_ValidProduct() throws IOException {
+    public void testGetIssuesUrl_Polaris() throws IOException {
         String jsonContent =
                 "{" + "\"data\": {\"polaris\": {\"project\": {\"issues\": {\"url\": \"http://example.com/issues\"}}}}}";
         ObjectMapper objectMapper = new ObjectMapper();
@@ -22,6 +23,44 @@ public class IssueCalculatorTest {
         String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
 
         assertEquals("http://example.com/issues", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_BlackDuckSca() throws IOException {
+        String jsonContent = "{" + "\"data\": {\"blackducksca\": {\"projectBomUrl\": \"http://bd.example.com/bom\"}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "blackducksca";
+
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+
+        assertEquals("http://bd.example.com/bom", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_Coverity() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"coverity\": {\"connect\": {\"resultURL\": \"http://coverity.example.com/result\"}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "coverity";
+
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+
+        assertEquals("http://coverity.example.com/result", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_Srm() throws IOException {
+        String jsonContent =
+                "{" + "\"data\": {\"srm\": {\"project\": {\"issues\": {\"url\": \"http://srm.example.com/issues\"}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "srm";
+
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+
+        assertEquals("http://srm.example.com/issues", issuesUrl);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
@@ -1,13 +1,12 @@
 package io.jenkins.plugins.security.scan.global;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 public class IssueCalculatorTest {
     IssueCalculator issueCalculator = new IssueCalculator();

--- a/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/global/IssueCalculatorTest.java
@@ -25,6 +25,49 @@ public class IssueCalculatorTest {
     }
 
     @Test
+    public void testGetIssuesUrl_CaseInsensitive_BlackDuckSca() throws IOException {
+        String jsonContent = "{" + "\"data\": {\"BLACKDUCKSCA\": {\"projectBomUrl\": \"http://bd.example.com/bom\"}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "blackducksca";
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+        assertEquals("http://bd.example.com/bom", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_CaseInsensitive_Coverity() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"COVERITY\": {\"CONNECT\": {\"resultURL\": \"http://coverity.example.com/result\"}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "coverity";
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+        assertEquals("http://coverity.example.com/result", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_CaseInsensitive_Polaris() throws IOException {
+        String jsonContent = "{"
+                + "\"data\": {\"POLARIS\": {\"project\": {\"issues\": {\"URL\": \"http://polaris.example.com/issues\"}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "polaris";
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+        assertEquals("http://polaris.example.com/issues", issuesUrl);
+    }
+
+    @Test
+    public void testGetIssuesUrl_CaseInsensitive_Srm() throws IOException {
+        String jsonContent =
+                "{" + "\"data\": {\"SRM\": {\"project\": {\"issues\": {\"URL\": \"http://srm.example.com/issues\"}}}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+        String product = "srm";
+        String issuesUrl = issueCalculator.getIssuesUrl(rootNode, product);
+        assertEquals("http://srm.example.com/issues", issuesUrl);
+    }
+
+    @Test
     public void testGetIssuesUrl_InvalidProduct() throws IOException {
         // Arrange
         String jsonContent = "{"


### PR DESCRIPTION
**Problem Description**
When environment variables such as `BRIDGE_COVERITY_INSTALL_DIRECTORY` are passed via Jenkins FreeStyle projects or Jenkinsfile configurations, the plugin fails to generate the Issue Count link on the Jenkins dashboard. This issue stems from a mismatch in how environment variable keys are handled—specifically, the plugin was unable to correctly parse keys from the _output.json_ file due to case sensitivity inconsistencies.

**Root Cause**
The Bridge tool generates keys in the `output.json` file using a case-insensitive approach, while the plugin expected exact-case matches for environment variable names. This mismatch prevented the plugin from correctly identifying and extracting the necessary data to render the Issue Count link.

**Fix Implemented**
The plugin logic has been updated to handle all keys in a case-insensitive manner, aligning with how Bridge generates them. This ensures that the plugin can now reliably extract the required values from _output.json_, regardless of the casing used in the environment variable names.