### PR TITLE
Implement SSL configuration support for Jenkins Plugin

### DIFF
--- a/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
@@ -171,6 +171,8 @@ public class ApplicationConstants {
     // Additional Parameters
     public static final String INCLUDE_DIAGNOSTICS_KEY = "include_diagnostics";
     public static final String NETWORK_AIRGAP_KEY = "network_airgap";
+    public static final String BRIDGE_NETWORK_SSL_TRUST_ALL_KEY = "bridge_network_ssl_trust_all";
+    public static final String BRIDGE_NETWORK_SSL_CERT_FILE_KEY = "bridge_network_ssl_cert_file";
     public static final String RETURN_STATUS_KEY = "return_status";
     public static final String BITBUCKET_USERNAME_KEY = "bitbucket_username";
     public static final String BITBUCKET_TOKEN_KEY = "bitbucket_token";

--- a/src/main/java/io/jenkins/plugins/security/scan/input/BridgeInput.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/BridgeInput.java
@@ -41,7 +41,7 @@ public class BridgeInput {
     private Gitlab gitlab;
 
     @JsonProperty("network")
-    private NetworkAirGap networkAirGap;
+    private Network network;
 
     @JsonProperty("reports")
     private Reports reports;
@@ -102,12 +102,12 @@ public class BridgeInput {
         this.bitbucket = bitbucket;
     }
 
-    public NetworkAirGap getNetworkAirGap() {
-        return networkAirGap;
+    public Network getNetwork() {
+        return network;
     }
 
-    public void setNetworkAirGap(final NetworkAirGap networkAirGap) {
-        this.networkAirGap = networkAirGap;
+    public void setNetwork(final Network network) {
+        this.network = network;
     }
 
     public Github getGithub() {

--- a/src/main/java/io/jenkins/plugins/security/scan/input/Network.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/Network.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.security.scan.input;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Network {
+    @JsonProperty("airgap")
+    private Boolean airgap;
+
+    @JsonProperty("ssl")
+    private Ssl ssl;
+
+    public Boolean getAirgap() {
+        return airgap;
+    }
+
+    public void setAirgap(final Boolean airgap) {
+        this.airgap = airgap;
+    }
+
+    public Ssl getSsl() {
+        return ssl;
+    }
+
+    public void setSsl(Ssl ssl) {
+        this.ssl = ssl;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/security/scan/input/Ssl.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/Ssl.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.security.scan.input;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Ssl {
+    @JsonProperty("trust")
+    private SslTrust trust;
+
+    @JsonProperty("cert")
+    private SslCert cert;
+
+    public SslTrust getTrust() {
+        return trust;
+    }
+
+    public void setTrust(SslTrust trust) {
+        this.trust = trust;
+    }
+
+    public SslCert getCert() {
+        return cert;
+    }
+
+    public void setCert(SslCert cert) {
+        this.cert = cert;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/security/scan/input/SslCert.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/SslCert.java
@@ -1,0 +1,16 @@
+package io.jenkins.plugins.security.scan.input;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SslCert {
+    @JsonProperty("file")
+    private String file;
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/security/scan/input/SslTrust.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/SslTrust.java
@@ -1,0 +1,16 @@
+package io.jenkins.plugins.security.scan.input;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SslTrust {
+    @JsonProperty("all")
+    private Boolean all;
+
+    public Boolean getAll() {
+        return all;
+    }
+
+    public void setAll(Boolean all) {
+        this.all = all;
+    }
+}


### PR DESCRIPTION
- Add SSL constants: BRIDGE_NETWORK_SSL_TRUST_ALL_KEY, BRIDGE_NETWORK_SSL_CERT_FILE_KEY in ApplicationConstants.java
- Created SSL input classes: Network.java, Ssl.java, SslTrust.java, SslCert.java
- Updated BridgeInput.java to use new Network class (replaced NetworkAirGap)
- Updated ToolsParameterService.java with comprehensive SSL configuration logic (45-line implementation)
- Add comprehensive test coverage (2 SSL-specific test methods)
- Environment Variable Logic: Sets bridge configuration with SSL parameters for all security tools
- Follow ssl.md specifications with consistent SSL structure across platforms

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
