### PR TITLE
SIGINT-4629 polaris fix pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 build/
 target/
 work/
+CLAUDE.md
+.claude

--- a/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
@@ -1,29 +1,23 @@
 package io.jenkins.plugins.security.scan.extension.pipeline;
 
-public interface FixPrScan {
-    public Boolean isBlackducksca_fixpr_enabled();
+interface FixPrScan {
+    Boolean isBlackducksca_fixpr_enabled();
 
-    public Boolean isBlackducksca_fixpr_enabled_actualValue();
+    Boolean isBlackducksca_fixpr_enabled_actualValue();
 
-    public String getBlackducksca_fixpr_filter_severities();
+    String getBlackducksca_fixpr_filter_severities();
 
-    public String getBlackducksca_fixpr_useUpgradeGuidance();
+    String getBlackducksca_fixpr_useUpgradeGuidance();
 
-    public Integer getBlackducksca_fixpr_maxCount();
+    Integer getBlackducksca_fixpr_maxCount();
 
-    public Boolean isPolaris_fixpr_enabled();
+    Boolean isPolaris_fixpr_enabled();
 
-    public Boolean isPolaris_fixpr_enabled_actualValue();
+    Boolean isPolaris_fixpr_enabled_actualValue();
 
-    public Integer getPolaris_fixpr_maxCount();
+    Integer getPolaris_fixpr_maxCount();
 
-    public Boolean isPolaris_fixpr_createSinglePR();
+    String getPolaris_fixpr_useUpgradeGuidance();
 
-    public Boolean isPolaris_fixpr_createSinglePR_actualValue();
-
-    public String getPolaris_fixpr_useUpgradeGuidance();
-
-    public String getPolaris_fixpr_filter_severities();
-
-    public String getPolaris_fixpr_filter_by();
+    String getPolaris_fixpr_filter_severities();
 }

--- a/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
@@ -10,4 +10,20 @@ public interface FixPrScan {
     public String getBlackducksca_fixpr_useUpgradeGuidance();
 
     public Integer getBlackducksca_fixpr_maxCount();
+
+    public Boolean isPolaris_fixpr_enabled();
+
+    public Boolean isPolaris_fixpr_enabled_actualValue();
+
+    public Integer getPolaris_fixpr_maxCount();
+
+    public Boolean isPolaris_fixpr_createSinglePR();
+
+    public Boolean isPolaris_fixpr_createSinglePR_actualValue();
+
+    public String getPolaris_fixpr_useUpgradeGuidance();
+
+    public String getPolaris_fixpr_filter_severities();
+
+    public String getPolaris_fixpr_filter_by();
 }

--- a/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/FixPrScan.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.security.scan.extension.pipeline;
 
-interface FixPrScan {
+public interface FixPrScan {
     Boolean isBlackducksca_fixpr_enabled();
 
     Boolean isBlackducksca_fixpr_enabled_actualValue();

--- a/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep.java
@@ -139,6 +139,14 @@ public class SecurityScanStep extends Step
     private String blackducksca_project_directory;
     private String polaris_project_directory;
     private String srm_project_directory;
+    private Boolean polaris_fixpr_enabled;
+    private Boolean polaris_fixpr_enabled_actualValue;
+    private Integer polaris_fixpr_maxCount;
+    private Boolean polaris_fixpr_createSinglePR;
+    private Boolean polaris_fixpr_createSinglePR_actualValue;
+    private String polaris_fixpr_useUpgradeGuidance;
+    private String polaris_fixpr_filter_severities;
+    private String polaris_fixpr_filter_by;
     private Boolean polaris_waitForScan;
     private Boolean polaris_waitForScan_actualValue;
 
@@ -541,6 +549,38 @@ public class SecurityScanStep extends Step
 
     public Boolean isProject_source_preserveSymLinks_actualValue() {
         return project_source_preserveSymLinks_actualValue;
+    }
+
+    public Boolean isPolaris_fixpr_enabled() {
+        return polaris_fixpr_enabled;
+    }
+
+    public Boolean isPolaris_fixpr_enabled_actualValue() {
+        return polaris_fixpr_enabled_actualValue;
+    }
+
+    public Integer getPolaris_fixpr_maxCount() {
+        return polaris_fixpr_maxCount;
+    }
+
+    public Boolean isPolaris_fixpr_createSinglePR() {
+        return polaris_fixpr_createSinglePR;
+    }
+
+    public Boolean isPolaris_fixpr_createSinglePR_actualValue() {
+        return polaris_fixpr_createSinglePR_actualValue;
+    }
+
+    public String getPolaris_fixpr_useUpgradeGuidance() {
+        return polaris_fixpr_useUpgradeGuidance;
+    }
+
+    public String getPolaris_fixpr_filter_severities() {
+        return polaris_fixpr_filter_severities;
+    }
+
+    public String getPolaris_fixpr_filter_by() {
+        return polaris_fixpr_filter_by;
     }
 
     public Boolean isPolaris_waitForScan() {
@@ -1167,6 +1207,38 @@ public class SecurityScanStep extends Step
     @DataBoundSetter
     public void setProject_source_excludes(String project_source_excludes) {
         this.project_source_excludes = Util.fixEmptyAndTrim(project_source_excludes);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_enabled(Boolean polaris_fixpr_enabled) {
+        this.polaris_fixpr_enabled = polaris_fixpr_enabled ? true : null;
+        this.polaris_fixpr_enabled_actualValue = polaris_fixpr_enabled ? true : false;
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_maxCount(Integer polaris_fixpr_maxCount) {
+        this.polaris_fixpr_maxCount = polaris_fixpr_maxCount;
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_createSinglePR(Boolean polaris_fixpr_createSinglePR) {
+        this.polaris_fixpr_createSinglePR = polaris_fixpr_createSinglePR ? true : null;
+        this.polaris_fixpr_createSinglePR_actualValue = polaris_fixpr_createSinglePR ? true : false;
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_useUpgradeGuidance(String polaris_fixpr_useUpgradeGuidance) {
+        this.polaris_fixpr_useUpgradeGuidance = Util.fixEmptyAndTrim(polaris_fixpr_useUpgradeGuidance);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_filter_severities(String polaris_fixpr_filter_severities) {
+        this.polaris_fixpr_filter_severities = Util.fixEmptyAndTrim(polaris_fixpr_filter_severities);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_fixpr_filter_by(String polaris_fixpr_filter_by) {
+        this.polaris_fixpr_filter_by = Util.fixEmptyAndTrim(polaris_fixpr_filter_by);
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep.java
@@ -142,11 +142,8 @@ public class SecurityScanStep extends Step
     private Boolean polaris_fixpr_enabled;
     private Boolean polaris_fixpr_enabled_actualValue;
     private Integer polaris_fixpr_maxCount;
-    private Boolean polaris_fixpr_createSinglePR;
-    private Boolean polaris_fixpr_createSinglePR_actualValue;
     private String polaris_fixpr_useUpgradeGuidance;
     private String polaris_fixpr_filter_severities;
-    private String polaris_fixpr_filter_by;
     private Boolean polaris_waitForScan;
     private Boolean polaris_waitForScan_actualValue;
 
@@ -563,24 +560,12 @@ public class SecurityScanStep extends Step
         return polaris_fixpr_maxCount;
     }
 
-    public Boolean isPolaris_fixpr_createSinglePR() {
-        return polaris_fixpr_createSinglePR;
-    }
-
-    public Boolean isPolaris_fixpr_createSinglePR_actualValue() {
-        return polaris_fixpr_createSinglePR_actualValue;
-    }
-
     public String getPolaris_fixpr_useUpgradeGuidance() {
         return polaris_fixpr_useUpgradeGuidance;
     }
 
     public String getPolaris_fixpr_filter_severities() {
         return polaris_fixpr_filter_severities;
-    }
-
-    public String getPolaris_fixpr_filter_by() {
-        return polaris_fixpr_filter_by;
     }
 
     public Boolean isPolaris_waitForScan() {
@@ -1221,12 +1206,6 @@ public class SecurityScanStep extends Step
     }
 
     @DataBoundSetter
-    public void setPolaris_fixpr_createSinglePR(Boolean polaris_fixpr_createSinglePR) {
-        this.polaris_fixpr_createSinglePR = polaris_fixpr_createSinglePR ? true : null;
-        this.polaris_fixpr_createSinglePR_actualValue = polaris_fixpr_createSinglePR ? true : false;
-    }
-
-    @DataBoundSetter
     public void setPolaris_fixpr_useUpgradeGuidance(String polaris_fixpr_useUpgradeGuidance) {
         this.polaris_fixpr_useUpgradeGuidance = Util.fixEmptyAndTrim(polaris_fixpr_useUpgradeGuidance);
     }
@@ -1234,11 +1213,6 @@ public class SecurityScanStep extends Step
     @DataBoundSetter
     public void setPolaris_fixpr_filter_severities(String polaris_fixpr_filter_severities) {
         this.polaris_fixpr_filter_severities = Util.fixEmptyAndTrim(polaris_fixpr_filter_severities);
-    }
-
-    @DataBoundSetter
-    public void setPolaris_fixpr_filter_by(String polaris_fixpr_filter_by) {
-        this.polaris_fixpr_filter_by = Util.fixEmptyAndTrim(polaris_fixpr_filter_by);
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
@@ -164,10 +164,8 @@ public class ApplicationConstants {
     public static final String POLARIS_TEST_SAST_LOCATION_KEY = "polaris_test_sast_location";
     public static final String POLARIS_FIXPR_ENABLED_KEY = "polaris_fixpr_enabled";
     public static final String POLARIS_FIXPR_MAXCOUNT_KEY = "polaris_fixpr_maxcount";
-    public static final String POLARIS_FIXPR_CREATE_SINGLE_PR_KEY = "polaris_fixpr_createSinglePR";
     public static final String POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY = "polaris_fixpr_useUpgradeGuidance";
     public static final String POLARIS_FIXPR_FILTER_SEVERITIES_KEY = "polaris_fixpr_filter_severities";
-    public static final String POLARIS_FIXPR_FILTER_BY_KEY = "polaris_fixpr_filter_by";
     public static final String POLARIS_WAITFORSCAN_KEY = "polaris_waitForScan";
 
     // SRM Parameters

--- a/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
@@ -162,6 +162,12 @@ public class ApplicationConstants {
     public static final String POLARIS_TEST_SAST_TYPE_KEY = "polaris_test_sast_type";
     public static final String POLARIS_TEST_SCA_LOCATION_KEY = "polaris_test_sca_location";
     public static final String POLARIS_TEST_SAST_LOCATION_KEY = "polaris_test_sast_location";
+    public static final String POLARIS_FIXPR_ENABLED_KEY = "polaris_fixpr_enabled";
+    public static final String POLARIS_FIXPR_MAXCOUNT_KEY = "polaris_fixpr_maxcount";
+    public static final String POLARIS_FIXPR_CREATE_SINGLE_PR_KEY = "polaris_fixpr_createSinglePR";
+    public static final String POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY = "polaris_fixpr_useUpgradeGuidance";
+    public static final String POLARIS_FIXPR_FILTER_SEVERITIES_KEY = "polaris_fixpr_filter_severities";
+    public static final String POLARIS_FIXPR_FILTER_BY_KEY = "polaris_fixpr_filter_by";
     public static final String POLARIS_WAITFORSCAN_KEY = "polaris_waitForScan";
 
     // SRM Parameters
@@ -342,6 +348,7 @@ public class ApplicationConstants {
 
     public static final String BLACKDUCK_FIXPR_INFO_FOR_NON_PR_SCANS =
             "Black Duck SCA Fix PR ignored for pull request scan";
+    public static final String POLARIS_FIXPR_INFO_FOR_NON_PR_SCANS = "Polaris Fix PR ignored for pull request scan";
 
     public static final String BLACKDUCK_SECURITY_SCAN_PLUGIN_DOCS_URL =
             "https://documentation.blackduck.com/bundle/bridge/page/documentation/c_using-jenkins-plugin.html";

--- a/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Filter.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Filter.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.security.scan.input.polaris;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class Filter {
+    @JsonProperty("severities")
+    private List<String> severities;
+
+    @JsonProperty("by")
+    private String by;
+
+    public List<String> getSeverities() {
+        return severities;
+    }
+
+    public void setSeverities(List<String> severities) {
+        this.severities = severities;
+    }
+
+    public String getBy() {
+        return by;
+    }
+
+    public void setBy(String by) {
+        this.by = by;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Filter.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Filter.java
@@ -7,22 +7,11 @@ public class Filter {
     @JsonProperty("severities")
     private List<String> severities;
 
-    @JsonProperty("by")
-    private String by;
-
     public List<String> getSeverities() {
         return severities;
     }
 
     public void setSeverities(List<String> severities) {
         this.severities = severities;
-    }
-
-    public String getBy() {
-        return by;
-    }
-
-    public void setBy(String by) {
-        this.by = by;
     }
 }

--- a/src/main/java/io/jenkins/plugins/security/scan/input/polaris/FixPr.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/polaris/FixPr.java
@@ -1,0 +1,61 @@
+package io.jenkins.plugins.security.scan.input.polaris;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class FixPr {
+    @JsonProperty("enabled")
+    private Boolean enabled;
+
+    @JsonProperty("maxCount")
+    private Integer maxCount;
+
+    @JsonProperty("createSinglePR")
+    private Boolean createSinglePR;
+
+    @JsonProperty("useUpgradeGuidance")
+    private List<String> useUpgradeGuidance;
+
+    @JsonProperty("filter")
+    private Filter filter;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Integer getMaxCount() {
+        return maxCount;
+    }
+
+    public void setMaxCount(Integer maxCount) {
+        this.maxCount = maxCount;
+    }
+
+    public Boolean getCreateSinglePR() {
+        return createSinglePR;
+    }
+
+    public void setCreateSinglePR(Boolean createSinglePR) {
+        this.createSinglePR = createSinglePR;
+    }
+
+    public List<String> getUseUpgradeGuidance() {
+        return useUpgradeGuidance;
+    }
+
+    public void setUseUpgradeGuidance(List<String> useUpgradeGuidance) {
+        this.useUpgradeGuidance = useUpgradeGuidance;
+    }
+
+    public Filter getFilter() {
+        return filter;
+    }
+
+    public void setFilter(Filter filter) {
+        this.filter = filter;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/security/scan/input/polaris/FixPr.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/polaris/FixPr.java
@@ -10,9 +10,6 @@ public class FixPr {
     @JsonProperty("maxCount")
     private Integer maxCount;
 
-    @JsonProperty("createSinglePR")
-    private Boolean createSinglePR;
-
     @JsonProperty("useUpgradeGuidance")
     private List<String> useUpgradeGuidance;
 
@@ -33,14 +30,6 @@ public class FixPr {
 
     public void setMaxCount(Integer maxCount) {
         this.maxCount = maxCount;
-    }
-
-    public Boolean getCreateSinglePR() {
-        return createSinglePR;
-    }
-
-    public void setCreateSinglePR(Boolean createSinglePR) {
-        this.createSinglePR = createSinglePR;
     }
 
     public List<String> getUseUpgradeGuidance() {

--- a/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Polaris.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/input/polaris/Polaris.java
@@ -32,6 +32,9 @@ public class Polaris {
     @JsonProperty("reports")
     private Reports reports;
 
+    @JsonProperty("fixPr")
+    private FixPr fixPr;
+
     @JsonProperty("waitForScan")
     private Boolean waitForScan;
 
@@ -112,6 +115,14 @@ public class Polaris {
 
     public void setTest(Test test) {
         this.test = test;
+    }
+
+    public FixPr getFixPr() {
+        return fixPr;
+    }
+
+    public void setFixPr(FixPr fixPr) {
+        this.fixPr = fixPr;
     }
 
     public Boolean isWaitForScan() {

--- a/src/main/java/io/jenkins/plugins/security/scan/service/ParameterMappingService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/ParameterMappingService.java
@@ -498,20 +498,12 @@ public class ParameterMappingService {
                     fixPrScan.getPolaris_fixpr_maxCount());
             addParameterIfNotBlank(
                     polarisParametersMap,
-                    ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY,
-                    fixPrScan.isPolaris_fixpr_createSinglePR_actualValue());
-            addParameterIfNotBlank(
-                    polarisParametersMap,
                     ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY,
                     fixPrScan.getPolaris_fixpr_useUpgradeGuidance());
             addParameterIfNotBlank(
                     polarisParametersMap,
                     ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY,
                     fixPrScan.getPolaris_fixpr_filter_severities());
-            addParameterIfNotBlank(
-                    polarisParametersMap,
-                    ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY,
-                    fixPrScan.getPolaris_fixpr_filter_by());
         }
 
         if (securityScan instanceof FreestyleScan) {

--- a/src/main/java/io/jenkins/plugins/security/scan/service/ParameterMappingService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/ParameterMappingService.java
@@ -486,6 +486,34 @@ public class ParameterMappingService {
             }
         }
 
+        if (securityScan instanceof FixPrScan) {
+            FixPrScan fixPrScan = (FixPrScan) securityScan;
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY,
+                    fixPrScan.isPolaris_fixpr_enabled_actualValue());
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY,
+                    fixPrScan.getPolaris_fixpr_maxCount());
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY,
+                    fixPrScan.isPolaris_fixpr_createSinglePR_actualValue());
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY,
+                    fixPrScan.getPolaris_fixpr_useUpgradeGuidance());
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY,
+                    fixPrScan.getPolaris_fixpr_filter_severities());
+            addParameterIfNotBlank(
+                    polarisParametersMap,
+                    ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY,
+                    fixPrScan.getPolaris_fixpr_filter_by());
+        }
+
         if (securityScan instanceof FreestyleScan) {
             FreestyleScan freestyleScan = (FreestyleScan) securityScan;
             preparePolarisToolConfigurationParametersMap(polarisParametersMap, freestyleScan);

--- a/src/main/java/io/jenkins/plugins/security/scan/service/ToolsParameterService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/ToolsParameterService.java
@@ -384,6 +384,9 @@ public class ToolsParameterService {
         if (scanParameters.containsKey(ApplicationConstants.BLACKDUCKSCA_FIXPR_ENABLED_KEY)
                 && Objects.equals(scanParameters.get(ApplicationConstants.BLACKDUCKSCA_FIXPR_ENABLED_KEY), true)) {
             return true;
+        } else if (scanParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY)
+                && Objects.equals(scanParameters.get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY), true)) {
+            return true;
         }
         return false;
     }

--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -328,7 +328,7 @@ public class PolarisParametersService {
                     .get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY)
                     .toString()
                     .trim();
-            if (value.equalsIgnoreCase("true")) {
+            if (value.equals("true")) {
                 boolean isPullRequestEvent = Utility.isPullRequestEvent(envVars);
                 if (isPullRequestEvent) {
                     logger.info(ApplicationConstants.POLARIS_FIXPR_INFO_FOR_NON_PR_SCANS);

--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -349,35 +349,14 @@ public class PolarisParametersService {
             fixPr.setMaxCount(maxCount);
         }
 
-        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY)) {
-            Boolean createSinglePR =
-                    (Boolean) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY);
-            fixPr.setCreateSinglePR(createSinglePR);
-        }
-
-        boolean hasFilterSeverities =
-                fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
-        boolean hasFilterBy = fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
-
-        if (hasFilterSeverities || hasFilterBy) {
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY)) {
             Filter filter = new Filter();
-
-            if (hasFilterSeverities) {
-                String filterSeverities =
-                        (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
-                String[] severitiesInput = filterSeverities.toUpperCase().split(",");
-                List<String> severities =
-                        Arrays.stream(severitiesInput).map(String::trim).collect(Collectors.toList());
-                filter.setSeverities(severities);
-            }
-
-            if (hasFilterBy) {
-                String filterBy = (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
-                if (filterBy != null && !filterBy.trim().isEmpty()) {
-                    filter.setBy(filterBy.toUpperCase().trim());
-                }
-            }
-
+            String filterSeverities =
+                    (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
+            String[] severitiesInput = filterSeverities.toUpperCase().split(",");
+            List<String> severities =
+                    Arrays.stream(severitiesInput).map(String::trim).collect(Collectors.toList());
+            filter.setSeverities(severities);
             fixPr.setFilter(filter);
         }
 

--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -328,7 +328,7 @@ public class PolarisParametersService {
                     .get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY)
                     .toString()
                     .trim();
-            if (value.equals("true")) {
+            if (value.equalsIgnoreCase("true")) {
                 boolean isPullRequestEvent = Utility.isPullRequestEvent(envVars);
                 if (isPullRequestEvent) {
                     logger.info(ApplicationConstants.POLARIS_FIXPR_INFO_FOR_NON_PR_SCANS);
@@ -355,26 +355,31 @@ public class PolarisParametersService {
             fixPr.setCreateSinglePR(createSinglePR);
         }
 
-        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY)) {
-            String filterSeverities =
-                    (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
-            String[] severitiesInput = filterSeverities.toUpperCase().split(",");
-            List<String> severities =
-                    Arrays.stream(severitiesInput).map(String::trim).collect(Collectors.toList());
-            if (!severities.isEmpty()) {
-                Filter filter = fixPr.getFilter() != null ? fixPr.getFilter() : new Filter();
-                filter.setSeverities(severities);
-                fixPr.setFilter(filter);
-            }
-        }
+        boolean hasFilterSeverities =
 
-        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY)) {
-            String filterBy = (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
-            if (filterBy != null && !filterBy.trim().isEmpty()) {
-                Filter filter = fixPr.getFilter() != null ? fixPr.getFilter() : new Filter();
-                filter.setBy(filterBy.toUpperCase().trim());
-                fixPr.setFilter(filter);
+                fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
+        boolean hasFilterBy = fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
+
+        if (hasFilterSeverities || hasFilterBy) {
+            Filter filter = new Filter();
+
+            if (hasFilterSeverities) {
+                String filterSeverities =
+                        (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
+                String[] severitiesInput = filterSeverities.toUpperCase().split(",");
+                List<String> severities =
+                        Arrays.stream(severitiesInput).map(String::trim).collect(Collectors.toList());
+                filter.setSeverities(severities);
             }
+
+            if (hasFilterBy) {
+                String filterBy = (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
+                if (filterBy != null && !filterBy.trim().isEmpty()) {
+                    filter.setBy(filterBy.toUpperCase().trim());
+                }
+            }
+
+            fixPr.setFilter(filter);
         }
 
         if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY)) {

--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -128,6 +128,7 @@ public class PolarisParametersService {
         setTestScaTypeAndSastType(polarisParameters, polaris);
         setTestScaTypeLocationAndSastTypeLocation(polarisParameters, polaris);
         setPolarisPrCommentInputs(polarisParameters, prcomment, polaris);
+        setFixPr(polarisParameters, polaris);
         setAssessmentMode(polarisParameters, polaris);
         setWaitForScan(polarisParameters, polaris);
 
@@ -319,6 +320,75 @@ public class PolarisParametersService {
             return true;
         }
         return false;
+    }
+
+    private void setFixPr(Map<String, Object> polarisParameters, Polaris polaris) {
+        if (polarisParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY)) {
+            String value = polarisParameters
+                    .get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY)
+                    .toString()
+                    .trim();
+            if (value.equals("true")) {
+                boolean isPullRequestEvent = Utility.isPullRequestEvent(envVars);
+                if (isPullRequestEvent) {
+                    logger.info(ApplicationConstants.POLARIS_FIXPR_INFO_FOR_NON_PR_SCANS);
+                } else {
+                    FixPr fixPr = prepareFixPrObject(polarisParameters);
+                    polaris.setFixPr(fixPr);
+                }
+            }
+        }
+    }
+
+    public FixPr prepareFixPrObject(Map<String, Object> fixPrParameters) {
+        FixPr fixPr = new FixPr();
+        fixPr.setEnabled(true);
+
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY)) {
+            Integer maxCount = (Integer) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY);
+            fixPr.setMaxCount(maxCount);
+        }
+
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY)) {
+            Boolean createSinglePR =
+                    (Boolean) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY);
+            fixPr.setCreateSinglePR(createSinglePR);
+        }
+
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY)) {
+            String filterSeverities =
+                    (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
+            String[] severitiesInput = filterSeverities.toUpperCase().split(",");
+            List<String> severities =
+                    Arrays.stream(severitiesInput).map(String::trim).collect(Collectors.toList());
+            if (!severities.isEmpty()) {
+                Filter filter = fixPr.getFilter() != null ? fixPr.getFilter() : new Filter();
+                filter.setSeverities(severities);
+                fixPr.setFilter(filter);
+            }
+        }
+
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY)) {
+            String filterBy = (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
+            if (filterBy != null && !filterBy.trim().isEmpty()) {
+                Filter filter = fixPr.getFilter() != null ? fixPr.getFilter() : new Filter();
+                filter.setBy(filterBy.toUpperCase().trim());
+                fixPr.setFilter(filter);
+            }
+        }
+
+        if (fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY)) {
+            String useUpgradeGuidance =
+                    (String) fixPrParameters.get(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY);
+            String[] guidanceInput = useUpgradeGuidance.toUpperCase().split(",");
+            List<String> guidance =
+                    Arrays.stream(guidanceInput).map(String::trim).collect(Collectors.toList());
+            if (!guidance.isEmpty()) {
+                fixPr.setUseUpgradeGuidance(guidance);
+            }
+        }
+
+        return fixPr;
     }
 
     private void setSarif(Map<String, Object> polarisParameters, Polaris polaris) {

--- a/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -356,7 +356,6 @@ public class PolarisParametersService {
         }
 
         boolean hasFilterSeverities =
-
                 fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY);
         boolean hasFilterBy = fixPrParameters.containsKey(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY);
 

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/config.jelly
@@ -214,6 +214,31 @@
             </f:advanced>
         </div>
 
+        <div id="polaris_fixPr_sec">
+            <f:advanced title="Fix Pull Request Options">
+                <f:entry field="polaris_fixpr_enabled" title="Create Fix Pull Requests (Optional)">
+                    <f:checkbox/>
+                </f:entry>
+                <div id="polaris_fixPr_params">
+                    <f:entry field="polaris_fixpr_maxCount" title="Maximum number of Pull Requests to be created (Optional)">
+                        <f:textbox/>
+                    </f:entry>
+                    <f:entry field="polaris_fixpr_createSinglePR" title="Create Single PR (Optional)">
+                        <f:checkbox/>
+                    </f:entry>
+                    <f:entry field="polaris_fixpr_useUpgradeGuidance" title="Configure Short Term or Long Term Guidance (Optional)">
+                        <f:textbox/>
+                    </f:entry>
+                    <f:entry field="polaris_fixpr_filter_severities" title="List of SEVERITIES to be filtered (Optional)">
+                        <f:textbox/>
+                    </f:entry>
+                    <f:entry field="polaris_fixpr_filter_by" title="Filter By (Optional)">
+                        <f:textbox/>
+                    </f:entry>
+                </div>
+            </f:advanced>
+        </div>
+
         <div id="polaris_sarif_report_sec">
             <f:advanced title="SARIF Report Options">
                 <f:entry field="polaris_reports_sarif_create" title="Generate SARIF Report(Optional)">

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/config.jelly
@@ -223,16 +223,10 @@
                     <f:entry field="polaris_fixpr_maxCount" title="Maximum number of Pull Requests to be created (Optional)">
                         <f:textbox/>
                     </f:entry>
-                    <f:entry field="polaris_fixpr_createSinglePR" title="Create Single PR (Optional)">
-                        <f:checkbox/>
-                    </f:entry>
                     <f:entry field="polaris_fixpr_useUpgradeGuidance" title="Configure Short Term or Long Term Guidance (Optional)">
                         <f:textbox/>
                     </f:entry>
                     <f:entry field="polaris_fixpr_filter_severities" title="List of SEVERITIES to be filtered (Optional)">
-                        <f:textbox/>
-                    </f:entry>
-                    <f:entry field="polaris_fixpr_filter_by" title="Filter By (Optional)">
                         <f:textbox/>
                     </f:entry>
                 </div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-blackducksca_fixpr_filter_severities.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-blackducksca_fixpr_filter_severities.html
@@ -1,3 +1,3 @@
 <div>
-    Filter the vulnerabilities by given severities, Fix PR(s) will be created only for issues where the issue severity matches one of the values specified using this option Values. Default is <code>CRITICAL, HIGH</code>.
+    Filter the vulnerabilities by given severities, Fix PR(s) will be created only for issues where the issue severity matches one of the values specified using this option. Default is <code>CRITICAL, HIGH</code>.
 </div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_createSinglePR.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_createSinglePR.html
@@ -1,0 +1,3 @@
+<div>
+    Create one combined fix pull request instead of multiple individual PRs. Default value is false.
+</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_createSinglePR.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_createSinglePR.html
@@ -1,3 +1,0 @@
-<div>
-    Create one combined fix pull request instead of multiple individual PRs. Default value is false.
-</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_enabled.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_enabled.html
@@ -1,0 +1,3 @@
+<div>
+    Flag to enable/disable the automatic fix pull request creations for Polaris. Default value is false.
+</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_by.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_by.html
@@ -1,0 +1,3 @@
+<div>
+    Filter mode for fix pull requests. Supported values: <code>POLICY</code> or <code>SEVERITIES</code>. Default is <code>POLICY</code>.
+</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_by.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_by.html
@@ -1,3 +1,0 @@
-<div>
-    Filter mode for fix pull requests. Supported values: <code>POLICY</code> or <code>SEVERITIES</code>. Default is <code>POLICY</code>.
-</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_severities.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_filter_severities.html
@@ -1,0 +1,3 @@
+<div>
+    Filter the vulnerabilities by given severities, Fix PR(s) will be created only for issues where the issue severity matches one of the values specified using this option. Comma-separated list of <code>CRITICAL</code>, <code>HIGH</code>, <code>MEDIUM</code>, <code>LOW</code>. Default is <code>CRITICAL, HIGH</code>.
+</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
@@ -1,3 +1,3 @@
 <div>
-    Maximum number of pull requests to be created that violate policies. PR is created for each vulnerable component. Default is <code>20</code>.
+    Maximum number of pull requests to be created that violate policies. PR is created for each vulnerable component. Default is <code>5</code>.
 </div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
@@ -1,3 +1,3 @@
 <div>
-    Maximum number of pull requests to be created that violate policies. PR is created for each vulnerable component. Not applicable when Create Single PR is enabled. Default is <code>20</code>.
+    Maximum number of pull requests to be created that violate policies. PR is created for each vulnerable component. Default is <code>20</code>.
 </div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_maxCount.html
@@ -1,0 +1,3 @@
+<div>
+    Maximum number of pull requests to be created that violate policies. PR is created for each vulnerable component. Not applicable when Create Single PR is enabled. Default is <code>20</code>.
+</div>

--- a/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_useUpgradeGuidance.html
+++ b/src/main/resources/io/jenkins/plugins/security/scan/extension/pipeline/SecurityScanStep/help-polaris_fixpr_useUpgradeGuidance.html
@@ -1,0 +1,3 @@
+<div>
+    Configure Short Term or Long Term Guidance - Polaris upgrade guidance values. Default is <code>SHORT_TERM, LONG_TERM</code>.
+</div>

--- a/src/main/webapp/scripts/SecurityScanStepConfig.js
+++ b/src/main/webapp/scripts/SecurityScanStepConfig.js
@@ -197,6 +197,15 @@ function toggleFixPrParamsDivs() {
             blackduckFixPrParamSection.style.display = 'none';
             clearInputFields(blackduckFixPrParamSection);
         }
+    } else if (selectedOption == "polaris") {
+        var polarisFixPrCheckbox = document.querySelector('input[name="_.polaris_fixpr_enabled"]')
+        var polarisFixPrParamSection = document.getElementById('polaris_fixPr_params')
+        if (polarisFixPrCheckbox.checked) {
+            polarisFixPrParamSection.style.display = 'block';
+        } else {
+            polarisFixPrParamSection.style.display = 'none';
+            clearInputFields(polarisFixPrParamSection);
+        }
     }
 }
 
@@ -225,14 +234,18 @@ function handlePostMergeWorkflowSectionsVisibility() {
     } else if (selectedOption === 'polaris') {
         var polarisSarif_section = document.getElementById('polaris_sarif_report_sec');
         var polarisPRComment_section = document.getElementById('polaris_pr_comment_sec');
+        var polarisFixPr_section = document.getElementById('polaris_fixPr_sec');
         if (polarisWaitForScanEnabled == false) {
             hideParticularDiv(polarisSarif_section);
             hideParticularDiv(polarisPRComment_section);
+            hideParticularDiv(polarisFixPr_section);
             clearInputFields(polarisSarif_section);
             clearInputFields(polarisPRComment_section);
+            clearInputFields(polarisFixPr_section);
         } else if (polarisWaitForScanEnabled == true) {
             showParticularDiv(polarisSarif_section);
             showParticularDiv(polarisPRComment_section);
+            showParticularDiv(polarisFixPr_section);
         }
     } else if (selectedOption === 'coverity') {
         var coverityPRComment_section = document.getElementById('coverity_pr_comment_sec');

--- a/src/main/webapp/scripts/SecurityScanStepConfig.js
+++ b/src/main/webapp/scripts/SecurityScanStepConfig.js
@@ -200,6 +200,7 @@ function toggleFixPrParamsDivs() {
     } else if (selectedOption == "polaris") {
         var polarisFixPrCheckbox = document.querySelector('input[name="_.polaris_fixpr_enabled"]')
         var polarisFixPrParamSection = document.getElementById('polaris_fixPr_params')
+        if (!polarisFixPrCheckbox || !polarisFixPrParamSection) return;
         if (polarisFixPrCheckbox.checked) {
             polarisFixPrParamSection.style.display = 'block';
         } else {

--- a/src/test/java/io/jenkins/plugins/security/scan/service/ParameterMappingServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/ParameterMappingServiceTest.java
@@ -361,21 +361,17 @@ public class ParameterMappingServiceTest {
         securityScanStep.setPolaris_branch_name("test");
         securityScanStep.setPolaris_fixpr_enabled(true);
         securityScanStep.setPolaris_fixpr_maxCount(5);
-        securityScanStep.setPolaris_fixpr_createSinglePR(true);
         securityScanStep.setPolaris_fixpr_useUpgradeGuidance("SHORT_TERM");
         securityScanStep.setPolaris_fixpr_filter_severities("CRITICAL,HIGH");
-        securityScanStep.setPolaris_fixpr_filter_by("POLICY");
 
         Map<String, Object> polarisParametersMap =
                 ParameterMappingService.preparePolarisParametersMap(securityScanStep);
 
         assertTrue((boolean) polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY));
         assertEquals(5, polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY));
-        assertTrue((boolean) polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY));
         assertEquals("SHORT_TERM", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY));
         assertEquals(
                 "CRITICAL,HIGH", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY));
-        assertEquals("POLICY", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/security/scan/service/ParameterMappingServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/ParameterMappingServiceTest.java
@@ -352,6 +352,33 @@ public class ParameterMappingServiceTest {
     }
 
     @Test
+    public void preparePolarisParametersMapWithFixPrTest() {
+        securityScanStep.setPolaris_server_url("https://fake.polaris-server.url");
+        securityScanStep.setPolaris_access_token("fake-access-token");
+        securityScanStep.setPolaris_application_name("fake-application-name");
+        securityScanStep.setPolaris_project_name("fake-project-name");
+        securityScanStep.setPolaris_assessment_types("SCA");
+        securityScanStep.setPolaris_branch_name("test");
+        securityScanStep.setPolaris_fixpr_enabled(true);
+        securityScanStep.setPolaris_fixpr_maxCount(5);
+        securityScanStep.setPolaris_fixpr_createSinglePR(true);
+        securityScanStep.setPolaris_fixpr_useUpgradeGuidance("SHORT_TERM");
+        securityScanStep.setPolaris_fixpr_filter_severities("CRITICAL,HIGH");
+        securityScanStep.setPolaris_fixpr_filter_by("POLICY");
+
+        Map<String, Object> polarisParametersMap =
+                ParameterMappingService.preparePolarisParametersMap(securityScanStep);
+
+        assertTrue((boolean) polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY));
+        assertEquals(5, polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY));
+        assertTrue((boolean) polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY));
+        assertEquals("SHORT_TERM", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY));
+        assertEquals(
+                "CRITICAL,HIGH", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY));
+        assertEquals("POLICY", polarisParametersMap.get(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY));
+    }
+
+    @Test
     public void preparePolarisParametersMapForFreestyleTest() {
         securityScanFreestyle.setProduct("POLARIS");
         securityScanFreestyle.setBitbucket_token("FAKETOKEN");

--- a/src/test/java/io/jenkins/plugins/security/scan/service/ToolsParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/ToolsParameterServiceTest.java
@@ -312,6 +312,50 @@ public class ToolsParameterServiceTest {
     }
 
     @Test
+    void bitbucket_polarisInputJson_withFixPrTest() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Mockito.doReturn(null).when(envVarsMock).get(ApplicationConstants.ENV_CHANGE_ID_KEY);
+
+        Polaris polaris = new Polaris();
+        polaris.setServerUrl("https://fake.polaris.url");
+        polaris.setAccessToken(TOKEN);
+        polaris.setApplicationName(new ApplicationName());
+        polaris.getApplicationName().setName("test");
+        polaris.setPolarisProject(new PolarisProject());
+        polaris.getPolarisProject().setName("test");
+        polaris.setAssessmentTypes(new AssessmentTypes());
+        polaris.getAssessmentTypes().setTypes(List.of("SCA", "SAST"));
+        polaris.setBranch(new Branch());
+        polaris.getBranch().setName("fake-pr-branch");
+
+        Map<String, Object> scanParameters = new HashMap<>();
+        scanParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
+
+        Bitbucket bitbucketObject = BitbucketRepositoryService.createBitbucketObject(
+                "https://bitbucket.org", TOKEN, null, "test", "test-branch", "abc", "fake-user");
+
+        try {
+            String expectedJson =
+                    "{\"data\":{\"polaris\":{\"serverUrl\":\"https://fake.polaris.url\",\"accesstoken\":\"MDJDSROSVC56FAKEKEY\",\"application\":{\"name\":\"test\"},\"project\":{\"name\":\"test\"},\"assessment\":{\"types\":[\"SCA\",\"SAST\"]},\"branch\":{\"name\":\"fake-pr-branch\"}},\"bitbucket\":{\"api\":{\"user\":{\"name\":\"fake-user\"},\"token\":\"MDJDSROSVC56FAKEKEY\"},\"project\":{\"repository\":{\"branch\":{\"name\":\"test-branch\"},\"name\":\"test\"}},\"workspace\":{\"id\":\"abc\"}},\"bridge\":{\"invoked\":{\"from\":\"Integrations-jenkins-pipeline\"}}}}";
+
+            String inputJsonPathForFixPr = toolsParameterService.prepareBridgeInputJson(
+                    scanParameters, polaris, bitbucketObject, ApplicationConstants.POLARIS_INPUT_JSON_PREFIX, null);
+            Path filePath = Paths.get(inputJsonPathForFixPr);
+
+            String actualJsonString = new String(Files.readAllBytes(filePath));
+
+            JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
+            JsonNode actualJsonNode = objectMapper.readTree(actualJsonString);
+
+            assertEquals(expectedJsonNode, actualJsonNode);
+            Utility.removeFile(filePath.toString(), workspace, listenerMock);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     void createSrmInputJsonTest() {
         SRM srm = new SRM();
         srm.setUrl("https://fake.srm.url");
@@ -705,6 +749,21 @@ public class ToolsParameterServiceTest {
 
         scanParameters.clear();
         assertFalse(ToolsParameterService.isPrCommentValueSet(scanParameters));
+    }
+
+    @Test
+    public void isFixPrValueSetTest() {
+        Map<String, Object> scanParameters = new HashMap<>();
+
+        scanParameters.put(ApplicationConstants.BLACKDUCKSCA_FIXPR_ENABLED_KEY, true);
+        assertTrue(ToolsParameterService.isFixPrValueSet(scanParameters));
+
+        scanParameters.clear();
+        scanParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
+        assertTrue(ToolsParameterService.isFixPrValueSet(scanParameters));
+
+        scanParameters.clear();
+        assertFalse(ToolsParameterService.isFixPrValueSet(scanParameters));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
@@ -6,6 +6,7 @@ import hudson.EnvVars;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.security.scan.input.coverity.Coverity;
+import io.jenkins.plugins.security.scan.input.polaris.FixPr;
 import io.jenkins.plugins.security.scan.input.polaris.Polaris;
 import io.jenkins.plugins.security.scan.input.project.Project;
 import io.jenkins.plugins.security.scan.input.report.Sarif;
@@ -351,6 +352,73 @@ public class PolarisParametersServiceTest {
         assertEquals(Arrays.asList("HIGH", "LOW"), sarifObject.getSeverities());
         assertEquals(List.of("SAST"), sarifObject.getIssue().getTypes());
         assertFalse(sarifObject.getGroupSCAIssues());
+    }
+
+    @Test
+    public void preparePolarisFixPrObjectTest() {
+        Map<String, Object> fixPrParameters = new HashMap<>();
+
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY, "CRITICAL,HIGH");
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY, "SHORT_TERM,LONG_TERM");
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY, 5);
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY, true);
+        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY, "POLICY");
+
+        FixPr fixPrObject = polarisParametersService.prepareFixPrObject(fixPrParameters);
+
+        assertNotNull(fixPrObject);
+        assertTrue(fixPrObject.getEnabled());
+        assertEquals(Arrays.asList("CRITICAL", "HIGH"), fixPrObject.getFilter().getSeverities());
+        assertEquals("POLICY", fixPrObject.getFilter().getBy());
+        assertEquals(Arrays.asList("SHORT_TERM", "LONG_TERM"), fixPrObject.getUseUpgradeGuidance());
+        assertEquals(5, fixPrObject.getMaxCount());
+        assertTrue(fixPrObject.getCreateSinglePR());
+    }
+
+    @Test
+    public void preparePolarisObjectForBridge_withFixPrInNonPRContextTest() {
+        Map<String, Object> polarisParameters = new HashMap<>();
+
+        polarisParameters.put(ApplicationConstants.POLARIS_SERVER_URL_KEY, TEST_POLARIS_SERVER_URL);
+        polarisParameters.put(ApplicationConstants.POLARIS_ACCESS_TOKEN_KEY, TEST_POLARIS_ACCESS_TOKEN);
+        polarisParameters.put(ApplicationConstants.POLARIS_APPLICATION_NAME_KEY, TEST_APPLICATION_NAME);
+        polarisParameters.put(ApplicationConstants.POLARIS_PROJECT_NAME_KEY, "fake-project-name");
+        polarisParameters.put(ApplicationConstants.POLARIS_ASSESSMENT_TYPES_KEY, "SCA");
+        polarisParameters.put(ApplicationConstants.POLARIS_BRANCH_NAME_KEY, "test-branch");
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY, 3);
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY, "CRITICAL");
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY, "SEVERITIES");
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY, "SHORT_TERM");
+
+        Polaris polaris = polarisParametersService.preparePolarisObjectForBridge(polarisParameters);
+
+        assertNotNull(polaris.getFixPr());
+        assertTrue(polaris.getFixPr().getEnabled());
+        assertEquals(3, polaris.getFixPr().getMaxCount());
+        assertEquals(Arrays.asList("CRITICAL"), polaris.getFixPr().getFilter().getSeverities());
+        assertEquals("SEVERITIES", polaris.getFixPr().getFilter().getBy());
+        assertEquals(Arrays.asList("SHORT_TERM"), polaris.getFixPr().getUseUpgradeGuidance());
+    }
+
+    @Test
+    public void preparePolarisObjectForBridge_fixPrIgnoredInPRContextTest() {
+        Map<String, Object> polarisParameters = new HashMap<>();
+
+        polarisParameters.put(ApplicationConstants.POLARIS_SERVER_URL_KEY, TEST_POLARIS_SERVER_URL);
+        polarisParameters.put(ApplicationConstants.POLARIS_ACCESS_TOKEN_KEY, TEST_POLARIS_ACCESS_TOKEN);
+        polarisParameters.put(ApplicationConstants.POLARIS_APPLICATION_NAME_KEY, TEST_APPLICATION_NAME);
+        polarisParameters.put(ApplicationConstants.POLARIS_PROJECT_NAME_KEY, "fake-project-name");
+        polarisParameters.put(ApplicationConstants.POLARIS_ASSESSMENT_TYPES_KEY, "SCA");
+        polarisParameters.put(ApplicationConstants.POLARIS_BRANCH_NAME_KEY, "test-branch");
+        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
+
+        Mockito.when(envVarsMock.get(ApplicationConstants.ENV_CHANGE_ID_KEY)).thenReturn("1");
+
+        Polaris polaris = polarisParametersService.preparePolarisObjectForBridge(polarisParameters);
+
+        assertNull(polaris.getFixPr());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/security/scan/service/scan/polaris/PolarisParametersServiceTest.java
@@ -362,18 +362,14 @@ public class PolarisParametersServiceTest {
         fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY, "CRITICAL,HIGH");
         fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY, "SHORT_TERM,LONG_TERM");
         fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY, 5);
-        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_CREATE_SINGLE_PR_KEY, true);
-        fixPrParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY, "POLICY");
 
         FixPr fixPrObject = polarisParametersService.prepareFixPrObject(fixPrParameters);
 
         assertNotNull(fixPrObject);
         assertTrue(fixPrObject.getEnabled());
         assertEquals(Arrays.asList("CRITICAL", "HIGH"), fixPrObject.getFilter().getSeverities());
-        assertEquals("POLICY", fixPrObject.getFilter().getBy());
         assertEquals(Arrays.asList("SHORT_TERM", "LONG_TERM"), fixPrObject.getUseUpgradeGuidance());
         assertEquals(5, fixPrObject.getMaxCount());
-        assertTrue(fixPrObject.getCreateSinglePR());
     }
 
     @Test
@@ -389,7 +385,6 @@ public class PolarisParametersServiceTest {
         polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_ENABLED_KEY, true);
         polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_MAXCOUNT_KEY, 3);
         polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_SEVERITIES_KEY, "CRITICAL");
-        polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_FILTER_BY_KEY, "SEVERITIES");
         polarisParameters.put(ApplicationConstants.POLARIS_FIXPR_USEUPGRADEGUIDANCE_KEY, "SHORT_TERM");
 
         Polaris polaris = polarisParametersService.preparePolarisObjectForBridge(polarisParameters);
@@ -398,7 +393,6 @@ public class PolarisParametersServiceTest {
         assertTrue(polaris.getFixPr().getEnabled());
         assertEquals(3, polaris.getFixPr().getMaxCount());
         assertEquals(Arrays.asList("CRITICAL"), polaris.getFixPr().getFilter().getSeverities());
-        assertEquals("SEVERITIES", polaris.getFixPr().getFilter().getBy());
         assertEquals(Arrays.asList("SHORT_TERM"), polaris.getFixPr().getUseUpgradeGuidance());
     }
 


### PR DESCRIPTION
This pull request adds support for configuring "Fix Pull Request" (Fix PR) options for Polaris scans in the Jenkins security scan plugin. It introduces new parameters, UI elements, and backend logic to enable the creation of automated fix PRs for vulnerabilities detected by Polaris, with various filtering and customization options.

Key changes include:

**Polaris Fix PR Feature Implementation:**

* Added new fields and corresponding getters/setters in `SecurityScanStep` and `FixPrScan` interfaces/classes to support Polaris Fix PR options such as enabling/disabling, maximum PR count, single PR creation, upgrade guidance, and filtering by severity or policy. [[1]](diffhunk://#diff-6e1a515c1838b4aae942c17460e080d1f62197e6621dd55e3e7911e203cd52d9R142-R149) [[2]](diffhunk://#diff-f3939685654ca8947c17dfdef4fc1b20dd5e214b3aa7e23e4d854980b50d680bR13-R28) [[3]](diffhunk://#diff-6e1a515c1838b4aae942c17460e080d1f62197e6621dd55e3e7911e203cd52d9R554-R585) [[4]](diffhunk://#diff-6e1a515c1838b4aae942c17460e080d1f62197e6621dd55e3e7911e203cd52d9R1212-R1243)
* Introduced new model classes `FixPr` and `Filter` to represent Fix PR configuration in the Polaris input structure. [[1]](diffhunk://#diff-9bd4b5573c95f25d7a3f013f57ac88ec233996bbaf8f79e2ec341c5e391be90dR1-R61) [[2]](diffhunk://#diff-f13a7726438ec1fc00917f8c7dacabe5acd03dd604a62ffb1b024bafa595c705R1-R28)
* Extended the `Polaris` class to include a `fixPr` field with appropriate getter/setter. [[1]](diffhunk://#diff-587c429b09bbecf9a8ee4de7f546549253f832de7c525c175f4c9ec87851e4dbR35-R37) [[2]](diffhunk://#diff-587c429b09bbecf9a8ee4de7f546549253f832de7c525c175f4c9ec87851e4dbR120-R127)

**Parameter Mapping and Processing:**

* Updated `ParameterMappingService` to map new Fix PR parameters from the pipeline configuration into the Polaris parameters map.
* Enhanced `PolarisParametersService` to construct and set the `FixPr` object in the Polaris input, including logic for parsing and validating filter and upgrade guidance options. [[1]](diffhunk://#diff-6901424b4c1bd8af52c670c406c8538f5f512ca1d31c5690e4c53e69fd9ef349R131) [[2]](diffhunk://#diff-6901424b4c1bd8af52c670c406c8538f5f512ca1d31c5690e4c53e69fd9ef349R325-R398)

**User Interface Enhancements:**

* Added new UI fields in the configuration Jelly file for all Polaris Fix PR options, allowing users to set these parameters in the Jenkins job configuration.
* Provided help documentation for each new field to guide users on their usage and default values. [[1]](diffhunk://#diff-35702208debbc2ef1d7318dacf3b4dd22548a0a3161147ce5f9675cead2f0c9fR1-R3) [[2]](diffhunk://#diff-356405cc2db51b048cf00670b68a341bd99a4aec2335b38299819d55583cbd1bR1-R3) [[3]](diffhunk://#diff-385a6f7b172c684426da812bf90251556acc709855bcc430de934f40e515a42dR1-R3) [[4]](diffhunk://#diff-6bc7e75f68d36d9fd50e0a09a7afdf43b736b4f5a8d4940fceda2f92db43a59cR1-R3) [[5]](diffhunk://#diff-a49589d465af09ff7a6d3beb2ff9f18a587db9ef2fc77119c78b114cb8baf409R1-R3) [[6]](diffhunk://#diff-95a0043f107f67f13b76f261f284485b78b24af9744335d444c1e1e730b84a9aR1-R3)

**Constants and Documentation:**

* Added new constants in `ApplicationConstants` for all Polaris Fix PR keys and info messages. [[1]](diffhunk://#diff-1f1b35fff7fe845e1cd60d04f92d56aab3f502ada1a4c5a6df2f196d15fd6e81R165-R170) [[2]](diffhunk://#diff-1f1b35fff7fe845e1cd60d04f92d56aab3f502ada1a4c5a6df2f196d15fd6e81R351)
* Minor improvement to help text for Black Duck SCA filter severities.

These changes collectively enable Jenkins users to automate the creation of fix pull requests for vulnerabilities detected by Polaris, with flexible configuration for filtering and PR creation strategy.