### PR TITLE
SIGINT-5928: CI products doc link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 You can download the latest artifact from releases: https://updates.jenkins-ci.org/download/plugins/blackduck-security-scan/
 
 ## 📄 Documentation
-Documentation for Black Duck Security Scan for Jenkins can be found [**here**](https://documentation.blackduck.com/bundle/bridge/page/documentation/c_using-jenkins-plugin.html)
+Documentation for Black Duck Security Scan for Jenkins can be found [**here**](https://docs.blackduck.com/r/bridge/latest/bridge-cli-guide/jenkins-black-duck-security-scan-plugin-for-jenkins.html)
 
 ## 👩‍💻 Developers Guide
 Please follow the steps described [**here**](DeveloperGuide.md)

--- a/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/security/scan/global/ApplicationConstants.java
@@ -351,7 +351,7 @@ public class ApplicationConstants {
     public static final String POLARIS_FIXPR_INFO_FOR_NON_PR_SCANS = "Polaris Fix PR ignored for pull request scan";
 
     public static final String BLACKDUCK_SECURITY_SCAN_PLUGIN_DOCS_URL =
-            "https://documentation.blackduck.com/bundle/bridge/page/documentation/c_using-jenkins-plugin.html";
+            "https://docs.blackduck.com/r/bridge/latest/bridge-cli-guide/jenkins-black-duck-security-scan-plugin-for-jenkins.html";
 
     public static final List<String> ARBITRARY_PARAM_KEYS = List.of(
             DETECT_SEARCH_DEPTH_KEY,


### PR DESCRIPTION
## Summary
Updated CI product documentation links to point to the new location.

## Changes
- Updated documentation URL in README.md
- Updated documentation URL in ApplicationConstants.java

## Testing Done
- Verified code changes locally.
- Confirmed updated documentation links are referenced correctly.

## Ticket
SIGINT-5928